### PR TITLE
feat: do not get full repo history

### DIFF
--- a/src/actions/helpers.ts
+++ b/src/actions/helpers.ts
@@ -43,6 +43,7 @@ export async function cloneRepo({
   await git.clone({
     url: remoteUrl,
     dir,
+    depth: 1,
   });
 
   await git.addRemote({


### PR DESCRIPTION
Added the `depth: 1` option to the `git clone`, as we don't need the full repo history here.